### PR TITLE
Show projected balance in day details

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@ const dailyNet=useMemo(()=>{const map=new Map();for(const d of monthGrid)map.set
 const dailyBalance=useMemo(()=>{const map=new Map();for(const d of monthGrid)map.set(toKey(d),projectBalance(state.transactions,state.anchors,d));return map},[monthGrid,state.transactions,state.anchors]);
 const selectedTransactions=useMemo(()=>state.transactions.filter(t=>occursOnDate(t,selectedDate)),[state.transactions,selectedDate]);
 const selectedNet=useMemo(()=>selectedTransactions.reduce((a,t)=>a+Number(t.amount),0),[selectedTransactions]);
+const selectedBalance=useMemo(()=>projectBalance(state.transactions,state.anchors,selectedDate),[state.transactions,state.anchors,selectedDate]);
 const monthName=new Intl.DateTimeFormat(undefined,{month:"long"}).format(new Date(viewYear,viewMonth,1));
 const forecast=useMemo(()=>{const start=startOfDay(new Date(viewYear,viewMonth,1));return Array.from({length:90},(_,i)=>{const d=addDays(start,i);return{date:toKey(d),bal:projectBalance(state.transactions,state.anchors,d)}})},[viewYear,viewMonth,state.transactions,state.anchors]);
 const lowDays=useMemo(()=>forecast.filter(p=>state.lowBalanceThreshold&&p.bal!==null&&p.bal<state.lowBalanceThreshold),[forecast,state.lowBalanceThreshold]);
@@ -88,7 +89,34 @@ return(<div className="min-h-screen bg-gray-50 text-gray-900"><div className="ma
 <Card><h2 className="text-lg font-semibold">90-day balance forecast</h2><MiniLineChart data={forecast} height={160}/></Card>
 </div></div>
 <footer className="max-w-7xl mx-auto p-4 text-xs text-gray-500">Pro tip: Use + amounts for income and − amounts for expenses. Set one or more known balances ("anchors") to get accurate projections in both directions.</footer>
-{showDetails&&(<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"><div className="bg-white rounded-xl p-4 w-80 max-h-[80vh] overflow-auto"><div className="flex items-center justify-between mb-2"><h3 className="font-semibold">{toKey(selectedDate)}</h3><button onClick={()=>setShowDetails(false)} className="text-gray-500 hover:text-gray-700">&times;</button></div>{selectedTransactions.length===0?(<p className="text-sm text-gray-600">No transactions</p>):(<ul className="space-y-1">{selectedTransactions.map(t=>(<li key={t.id} className="flex justify-between text-sm"><span>{t.label}</span><span className={Number(t.amount)>=0?"text-green-600":"text-red-600"}>{currency(Number(t.amount))}</span></li>))}</ul>)}<div className="mt-2 text-sm text-gray-600">Net: <span className={selectedNet>=0?"text-green-600":"text-red-600"}>{currency(selectedNet)}</span></div></div></div>)}
+{showDetails&&(
+  <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div className="bg-white rounded-xl p-4 w-80 max-h-[80vh] overflow-auto">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="font-semibold">{toKey(selectedDate)}</h3>
+        <button onClick={()=>setShowDetails(false)} className="text-gray-500 hover:text-gray-700">&times;</button>
+      </div>
+      {selectedTransactions.length===0?(
+        <p className="text-sm text-gray-600">No transactions</p>
+      ):(
+        <ul className="space-y-1">
+          {selectedTransactions.map(t=>(
+            <li key={t.id} className="flex justify-between text-sm">
+              <span>{t.label}</span>
+              <span className={Number(t.amount)>=0?"text-green-600":"text-red-600"}>{currency(Number(t.amount))}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="mt-2 text-sm text-gray-600">
+        Net: <span className={selectedNet>=0?"text-green-600":"text-red-600"}>{currency(selectedNet)}</span>
+      </div>
+      <div className="mt-1 text-sm text-gray-600">
+        Projected balance: <span className={`${selectedBalance===null?"text-gray-400":selectedBalance>=0?"text-gray-900":"text-red-600"}`}>{currency(selectedBalance)}</span>
+      </div>
+    </div>
+  </div>
+)}
 {showMonthSummary&&(<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"><div className="bg-white rounded-xl p-4 w-80 max-h-[80vh] overflow-auto"><div className="flex items-center justify-between mb-2"><h3 className="font-semibold">{monthName} {viewYear} Summary</h3><button onClick={()=>{setShowMonthSummary(false);setShowDailyBreakdown(false);}} className="text-gray-500 hover:text-gray-700">&times;</button></div><ul className="space-y-1 text-sm"><li className="flex justify-between"><span>Income</span><span className="text-green-600">{currency(monthSummary.income)}</span></li><li className="flex justify-between"><span>Expenses</span><span className="text-red-600">{currency(Math.abs(monthSummary.expense))}</span></li><li className="flex justify-between"><span>Net</span><span className={monthSummary.net>=0?"text-green-600":"text-red-600"}>{currency(monthSummary.net)}</span></li>{monthSummary.highest!=null&&(<li className="flex justify-between"><span>Highest balance</span><span>{currency(monthSummary.highest)}</span></li>)}{monthSummary.lowest!=null&&(<li className="flex justify-between"><span>Lowest balance</span><span>{currency(monthSummary.lowest)}</span></li>)}{state.lowBalanceThreshold>0&&(<li className="flex justify-between"><span>Days below threshold</span><span>{monthSummary.lowCount}</span></li>)}</ul><button onClick={()=>setShowDailyBreakdown(v=>!v)} className="mt-2 text-sm text-indigo-600 hover:underline">{showDailyBreakdown?"Hide":"Show"} daily breakdown</button>{showDailyBreakdown&&(<div className="mt-2 max-h-40 overflow-auto border-t pt-2">{monthGrid.filter(d=>d.getMonth()===viewMonth).map(d=>{const k=toKey(d);const net=dailyNet.get(k)||0;return(<div key={k} className="flex justify-between text-sm"><span>{d.getDate()}</span><span className={net>=0?"text-green-600":"text-red-600"}>{currency(net)}</span></div>)})}</div>)}<div className="mt-4 border-t pt-2"><div className="flex items-center justify-between"><h4 className="font-semibold">Transactions</h4><div className="flex gap-1 text-xs"><button onClick={()=>setSummaryFilter("all")} className={`px-2 py-1 rounded-full ${summaryFilter==="all"?"bg-gray-900 text-white":"bg-gray-200"}`}>All</button><button onClick={()=>setSummaryFilter("income")} className={`px-2 py-1 rounded-full ${summaryFilter==="income"?"bg-gray-900 text-white":"bg-gray-200"}`}>Income</button><button onClick={()=>setSummaryFilter("expense")} className={`px-2 py-1 rounded-full ${summaryFilter==="expense"?"bg-gray-900 text-white":"bg-gray-200"}`}>Expenses</button></div></div>{filteredMonthTransactions.length===0?(<p className="text-sm text-gray-600 mt-2">No transactions</p>):(<ul className="mt-2 space-y-1 max-h-40 overflow-auto">{filteredMonthTransactions.map(t=>(<li key={t.id} className="flex items-center justify-between text-sm"><div className="flex-1"><div className="font-medium">{t.label}</div><div className="text-xs text-gray-500">{describeRule(t)}</div></div><div className="flex items-center gap-2 ml-2"><span className={Number(t.amount)>=0?"text-green-600":"text-red-600"}>{currency(Number(t.amount))}</span><button onClick={()=>setEditingTx(t)} className="text-indigo-600 hover:underline">Edit</button><button onClick={()=>deleteTransaction(t.id)} className="text-red-600 hover:underline">Delete</button></div></li>))}</ul>)}</div></div></div>)}
 {editingTx&&(<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"><div className="bg-white rounded-xl p-4 w-80 max-h-[80vh] overflow-auto"><div className="flex items-center justify-between mb-2"><h3 className="font-semibold">Edit Transaction</h3><button onClick={()=>setEditingTx(null)} className="text-gray-500 hover:text-gray-700">&times;</button></div><TransactionForm initial={editingTx} onSubmit={editTransaction} submitLabel="Save" onCancel={()=>setEditingTx(null)}/></div></div>)}
 </div>)};


### PR DESCRIPTION
## Summary
- compute projected balance for selected date
- display projected balance in the day details modal

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991531fa80832ab6968ef78e24a8c0