### PR TITLE
Add SVG app icon, pin frontend libs, and improve service worker caching

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Budget app icon">
+  <rect width="512" height="512" rx="96" fill="#111827"/>
+  <circle cx="256" cy="256" r="184" fill="#f9fafb"/>
+  <path d="M160 224h192v64H160z" fill="#22c55e"/>
+  <path d="M192 176h128v40H192zM192 296h128v40H192z" fill="#111827"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <link rel="manifest" href="manifest.json"><meta name="theme-color" content="#111827"/>
 <title>Interactive Budgeting App</title>
 <script src="https://cdn.tailwindcss.com"></script>
-<script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<script src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.24.7/babel.min.js"></script>
 <style>.btn{padding:.375rem .75rem;border-radius:.75rem;background:#111827;color:#fff}.btn:hover{opacity:.9}.input{width:100%;padding:.5rem .75rem;border:1px solid #e5e7eb;border-radius:.75rem;background:#fff}.label{display:block;font-size:.875rem;color:#4b5563;margin-bottom:.25rem}</style></head>
 <body class="min-h-screen bg-gray-50">
 <div class="max-w-3xl mx-auto p-4"><h1 class="text-2xl font-bold mb-2">Interactive Budgeting App</h1>

--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,9 @@
   "theme_color": "#111827",
   "icons": [
     {
-      "src": "icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
+      "src": "icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
       "purpose": "any maskable"
     }
   ]

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,11 +1,9 @@
-const CACHE_NAME = 'budget-pwa-v2';
+const CACHE_NAME = 'budget-pwa-v3';
 const OFFLINE_ASSETS = [
+  './',
+  './index.html',
   './manifest.json',
-  './icon-512.png',
-  'https://cdn.tailwindcss.com',
-  'https://unpkg.com/react@18/umd/react.production.min.js',
-  'https://unpkg.com/react-dom@18/umd/react-dom.production.min.js',
-  'https://unpkg.com/@babel/standalone/babel.min.js'
+  './icon.svg'
 ];
 
 self.addEventListener('install', (event) => {
@@ -34,14 +32,21 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  if (new URL(req.url).origin !== self.location.origin) {
+    event.respondWith(fetch(req));
+    return;
+  }
+
   event.respondWith(
     caches.match(req).then((hit) => {
       if (hit) return hit;
       return fetch(req).then((res) => {
-        const resClone = res.clone();
-        caches.open(CACHE_NAME).then((cache) => cache.put(req, resClone)).catch(() => {});
+        if (req.method === 'GET' && res.ok) {
+          const resClone = res.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(req, resClone)).catch(() => {});
+        }
         return res;
-      }).catch(() => Promise.reject('offline'));
+      }).catch(() => caches.match('./index.html'));
     })
   );
 });


### PR DESCRIPTION
### Motivation

- Provide a scalable PWA icon and update the web manifest to use an SVG asset for better quality and maskable support.
- Pin CDN library versions to avoid unexpected breaking changes from floating tags.
- Harden service worker caching behavior and update cache version to improve offline reliability and security.

### Description

- Added `icon.svg` as the app icon and updated `manifest.json` to reference `icon.svg` with `sizes: "any"` and `type: "image/svg+xml"`.
- Updated `index.html` to pin React and ReactDOM to `18.2.0` and `@babel/standalone` to `7.24.7` to stabilize runtime dependencies.
- Reworked `service-worker.js` by bumping `CACHE_NAME` to `budget-pwa-v3`, adding `./` and `./index.html` and `./icon.svg` to the offline assets, and removing remote CDN entries from pre-cache.
- Improved runtime fetch handling by bypassing cross-origin requests, caching only `GET` responses with `res.ok`, and using `./index.html` as the offline navigation fallback.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e2ac7f3dc832aa996222a61c64b64)